### PR TITLE
Fix broken split and combine test

### DIFF
--- a/pony-kafka/_test.pony
+++ b/pony-kafka/_test.pony
@@ -539,6 +539,7 @@ primitive _ProduceApiCombineSplitTest
     let topic_partition_state = _KafkaTopicPartitionState(0, partition_id, 0,
       recover Array[I32] end, recover Array[I32] end)
     topic_partition_state.current_leader = true
+    topic_partition_state.leader_change = false
     topic_state.partitions_state(partition_id) = topic_partition_state
     state.topics_state(topic) = topic_state
 
@@ -547,6 +548,7 @@ primitive _ProduceApiCombineSplitTest
     let topic2_partition_state = _KafkaTopicPartitionState(0, partition_id, 0,
       recover Array[I32] end, recover Array[I32] end)
     topic2_partition_state.current_leader = false
+    topic2_partition_state.leader_change = false
     topic2_state.partitions_state(partition_id) = topic2_partition_state
     state.topics_state(topic2) = topic2_state
 


### PR DESCRIPTION
This test was broken because it didn't properly account for changes
to how leader change state is initialized.

Resolves #3