### PR TITLE
Make sure to send 0 and not -1 for message offset for wrapper message

### DIFF
--- a/pony-kafka/kafka_api.pony
+++ b/pony-kafka/kafka_api.pony
@@ -583,7 +583,7 @@ primitive _KafkaMessageSetCodecV0V1
           let msg: ProducerKafkaMessage val = recover
             ProducerKafkaMessage(producer, None, compressed_data,
             compressed_data.size() where timestamp = timestamp) end
-          encode_message(wb_msgs, msg, -1, version, KafkaGzipTopicCompression)
+          encode_message(wb_msgs, msg, 0, version, KafkaGzipTopicCompression)
         else
           logger(Error) and logger.log(Error, "Error compressing messages " +
             "using GZip. Falling back to uncompressed messages.")
@@ -622,7 +622,7 @@ primitive _KafkaMessageSetCodecV0V1
           let msg: ProducerKafkaMessage val = recover
             ProducerKafkaMessage(producer, None, compressed_data,
             compressed_data.size() where timestamp = timestamp) end
-          encode_message(wb_msgs, msg, -1, version, KafkaSnappyTopicCompression)
+          encode_message(wb_msgs, msg, 0, version, KafkaSnappyTopicCompression)
         else
           logger(Error) and logger.log(Error, "Error compressing messages " +
             "using Snappy. Falling back to uncompressed messages.")
@@ -665,7 +665,7 @@ primitive _KafkaMessageSetCodecV0V1
           let msg: ProducerKafkaMessage val = recover
             ProducerKafkaMessage(producer, None, compressed_data',
             compressed_data'.size() where timestamp = timestamp) end
-          encode_message(wb_msgs, msg, -1, version, KafkaLZ4TopicCompression)
+          encode_message(wb_msgs, msg, 0, version, KafkaLZ4TopicCompression)
         else
           logger(Error) and logger.log(Error, "Error compressing messages " +
             "using LZ4. Falling back to uncompressed messages.")


### PR DESCRIPTION
Prior to this commit, whenever we compressed a set of messages as a single
wrapper message we would set the message offset to be -1. This wasn't
an issue with Kafka Brokers < 0.11 but starting 0.11 the broker enforced
that the message offset should be `0` or greater than `0`.

This commit ensures the wrapper message always gets `0` for it's message
offset since the broker will auto assign valid offsets based on the
internally compressed message offsets.

resolves #39