### PR TITLE
Fix invalid throttling edge case

### DIFF
--- a/pony-kafka/kafka_api.pony
+++ b/pony-kafka/kafka_api.pony
@@ -1980,6 +1980,8 @@ primitive _KafkaFetchV0 is _KafkaFetchApi
     var num_partitions_encoded: I32 = 0
     for (part_id, part_state) in parts_state.pairs() do
       if (not part_state.current_leader) or part_state.paused then
+        conf.logger(Fine) and conf.logger.log(Fine, "Ignoring topic: " + topic + ", partition: "
+           + part_state.partition_id.string())
         continue
       end
       if num_partitions_encoded == 0 then


### PR DESCRIPTION
Prior to this commit, if a broker connection that didn't own any
partitions was disconnected, it would cause producers to get
throttled even if no topics/partitions were actually throttled.

This commit fixes the issue.