### PR TITLE
Compatibility with ponyc master + feature improvements + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The main reason this exists is because the alternatives weren't necessarily goin
 
 # Building
 
-You need [ponyc](https://github.com/ponylang/ponyc) to compile `pony-kafka`. This is currently tested with `ponyc` version 0.19.2.
+You need [ponyc](https://github.com/ponylang/ponyc) to compile `pony-kafka`. This is currently tested with `ponyc` version 0.21.3.
 
 You also need the following (in addition to what is needed for Pony itself):
 
@@ -41,11 +41,21 @@ For OSX you can run:
 brew install snappy lz4
 ```
 
+You can then build the pony-kafka tests by running:
+
+```bash
+ponyc pony-kafka
+```
+
+or the example performance application by running:
+
+```bash
+ponyc examples/performance
+```
+
 # Current status
 
 This is currently alpha quality software that still needs more work before it is production ready.
-
-You currently need the latest Wallaroo Labs version of Pony (https://github.com/WallarooLabs/ponyc). Mainline Pony compatibility is already planned for the near future.
 
 A quick summary of features:
 
@@ -58,9 +68,14 @@ Leader Failover | Ability to correctly recover from/react to kafka leader failov
 Compression | Ability to use LZ4/Snappy/Zlib compression for message sets | Implemented
 Message Format V2 | Ability to use message set format version 2 | Not Implemented
 Idempotence/Transaction | Ability to use idempotence/transactions | Not Implemented
+Metrics | Ability to collect metrics and provide reports of metrics periodically | Not Implemented
+Security | Ability to use SSL/SASL/etc to secure connection to Kafka brokers | Not Implemented
+Message Interceptors | Ability to intercept messages before produce and after consume to be able to modify them or extract metadata from them for monitoring and other purposes | Not Implemented
 Producer Batching | Ability to batch produce requests for efficiency | Implemented
 Producer Rate Limiting | Ability to limit number of outstanding produce requests | Implemented
 Throttling | Ability to tell producers of data to slow down due to network congestion | Implemented
 Message Delivery Reports | Report back to producers once Kafka has confirm message has been successfully stored | Implemented
 Logging | Logging of what is happening/errors | Partially Implemented
 Error Handling | Ability to gracefully handle errors (retry if possible; fail fast if not) | Partially Implemented
+Documentation | Comprehensive documentation for developers using Pony Kafka and developers enhancing Pony Kafka | Not Implemented
+Testing | Comprehensive test suite to confirm everything is working as expected | Not Implemented

--- a/examples/performance/main.pony
+++ b/examples/performance/main.pony
@@ -338,8 +338,7 @@ actor P is KafkaProducer
   fun ref producer_mapping(): (KafkaProducerMapping | None) =>
     _kafka_producer_mapping
 
-  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val)
+  fun ref _kafka_producer_throttled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     ifdef debug then
       @printf[I32]("Producer throttled\n".cstring())
@@ -349,14 +348,13 @@ actor P is KafkaProducer
       _throttled = true
     end
 
-  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val, fully_unthrottled: Bool)
+  fun ref _kafka_producer_unthrottled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     ifdef debug then
-      @printf[I32](("Producer unthrottled. fully_unthrottled: " + fully_unthrottled.string() + "\n").cstring())
+      @printf[I32](("Producer unthrottled. num partitions throttled: " + topic_partitions_throttled.size().string() + "\n").cstring())
     end
 
-    if fully_unthrottled and _throttled then
+    if (topic_partitions_throttled.size() == 0) and _throttled then
       _throttled = false
       match _kafka_producer_mapping
       | let p: KafkaProducerMapping => produce_data()

--- a/examples/simple/main.pony
+++ b/examples/simple/main.pony
@@ -124,13 +124,11 @@ actor P is KafkaProducer
   fun ref producer_mapping(): (KafkaProducerMapping | None) =>
     _kafka_producer_mapping
 
-  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val)
+  fun ref _kafka_producer_throttled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 
-  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val, fully_unthrottled: Bool)
+  fun ref _kafka_producer_unthrottled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 

--- a/examples/simple/main.pony
+++ b/examples/simple/main.pony
@@ -27,7 +27,7 @@ actor Main is KafkaClientManager
 
   new create(env: Env) =>
     _env = env
-    _logger = StringLogger(Warn, env.out)
+    _logger = StringLogger(Fine, env.out)
 
     // create kafka config
     let kconf =
@@ -62,7 +62,7 @@ actor Main is KafkaClientManager
     end
 
   be receive_kafka_topics_partitions(topic_partitions: Map[String,
-    (KafkaTopicType, Set[I32])] val) =>
+    (KafkaTopicType, Set[KafkaPartitionId])] val) =>
     match _kc
     | let kc: KafkaClient tag =>
       let consumers = recover iso Array[KafkaConsumer tag] end
@@ -124,12 +124,12 @@ actor P is KafkaProducer
   fun ref producer_mapping(): (KafkaProducerMapping | None) =>
     _kafka_producer_mapping
 
-  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[I32, I32]]
+  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
     val)
   =>
     None
 
-  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[I32, I32]]
+  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
     val, fully_unthrottled: Bool)
   =>
     None

--- a/pony-kafka/_test.pony
+++ b/pony-kafka/_test.pony
@@ -48,22 +48,22 @@ actor TestP is KafkaProducer
   new create() =>
     None
 
-  fun ref create_producer_mapping(mapping: KafkaProducerMapping):
+  fun ref create_producer_mapping(client: KafkaClient, mapping: KafkaProducerMapping):
     (KafkaProducerMapping | None) => None
 
-  be kafka_producer_ready() => None
+  be kafka_producer_ready(client: KafkaClient) => None
 
-  be kafka_message_delivery_report(delivery_report: KafkaProducerDeliveryReport)
+  be kafka_message_delivery_report(client: KafkaClient, delivery_report: KafkaProducerDeliveryReport)
   =>
     None
 
-  fun ref producer_mapping(): (KafkaProducerMapping | None) => None
+  fun ref producer_mapping(client: KafkaClient): (KafkaProducerMapping | None) => None
 
-  fun ref _kafka_producer_throttled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
+  fun ref _kafka_producer_throttled(client: KafkaClient, topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 
-  fun ref _kafka_producer_unthrottled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
+  fun ref _kafka_producer_unthrottled(client: KafkaClient, topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 

--- a/pony-kafka/_test.pony
+++ b/pony-kafka/_test.pony
@@ -59,13 +59,11 @@ actor TestP is KafkaProducer
 
   fun ref producer_mapping(): (KafkaProducerMapping | None) => None
 
-  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val)
+  fun ref _kafka_producer_throttled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 
-  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[KafkaPartitionId, KafkaNodeId]]
-    val, fully_unthrottled: Bool)
+  fun ref _kafka_producer_unthrottled(topic_partitions_throttled: Map[String, Set[KafkaPartitionId]] val)
   =>
     None
 

--- a/pony-kafka/compression/_test.pony
+++ b/pony-kafka/compression/_test.pony
@@ -37,14 +37,14 @@ class iso _TestXXHash is UnitTest
   fun apply(h: TestHelper) ? =>
     let d = [as U8: 1; 2; 6; 10; 42; 'H'; 'e'; 'l'; 'l'; 'o'; ','; ' '; 'w'
       'o'; 'r'; 'l'; 'd'; '!'; 0; 2; 56; 99]
-    h.assert_eq[U32](0x02cc5d05, XXHash.hash32(Array[U8], 0)? as U32)
-    h.assert_eq[U32](0xe0fe705f, XXHash.hash32([as U8: 42], 0)? as U32)
+    h.assert_eq[U32](0x02cc5d05, XXHash.hash32(Array[U8], 0)?)
+    h.assert_eq[U32](0xe0fe705f, XXHash.hash32([as U8: 42], 0)?)
     h.assert_eq[U32](0x9e5e7e93, XXHash.hash32([as U8: 'H'; 'e'; 'l'; 'l'; 'o'
-      ','; ' '; 'w'; 'o'; 'r'; 'l'; 'd'; '!'; 0], 0)? as U32)
-    h.assert_eq[U32](0xd6bf8459, XXHash.hash32(Array[U8], 0x42c91977)? as U32)
-    h.assert_eq[U32](0x02cc5d05, XXHash.hash32(d, 0, 4, 0)? as U32)
-    h.assert_eq[U32](0xe0fe705f, XXHash.hash32(d, 0, 4, 1)? as U32)
-    h.assert_eq[U32](0x9e5e7e93, XXHash.hash32(d, 0, 5, 14)? as U32)
+      ','; ' '; 'w'; 'o'; 'r'; 'l'; 'd'; '!'; 0], 0)?)
+    h.assert_eq[U32](0xd6bf8459, XXHash.hash32(Array[U8], 0x42c91977)?)
+    h.assert_eq[U32](0x02cc5d05, XXHash.hash32(d, 0, 4, 0)?)
+    h.assert_eq[U32](0xe0fe705f, XXHash.hash32(d, 0, 4, 1)?)
+    h.assert_eq[U32](0x9e5e7e93, XXHash.hash32(d, 0, 5, 14)?)
 
 class iso _TestZlib is UnitTest
   """

--- a/pony-kafka/compression/xxhash.pony
+++ b/pony-kafka/compression/xxhash.pony
@@ -20,12 +20,15 @@ primitive XXHash
   // TODO: hash64
   // TODO: should null terminator for strings be included? to match behavior of
   // C string hashing?
-  fun hash32(buffer: String, seed: U32, buffer_offset: USize, num_bytes: USize):
+  fun hash32(buffer: (String | Array[U8] box), seed: U32, buffer_offset: USize = 0, num_bytes: USize = -1):
     U32 ?
   =>
-    hash32(buffer.array(), seed, buffer_offset, num_bytes)?
+    match buffer
+    | let b: String => _hash32(b.array(), seed, buffer_offset, num_bytes)?
+    | let b: Array[U8] box => _hash32(b, seed, buffer_offset, num_bytes)?
+    end
 
-  fun hash32(buffer: Array[U8] box, seed: U32 = 0, buffer_offset: USize = 0,
+  fun _hash32(buffer: Array[U8] box, seed: U32 = 0, buffer_offset: USize = 0,
     num_bytes: USize = -1): U32 ?
   =>
     var h32: U32 = 0

--- a/pony-kafka/custombuffered/_test.pony
+++ b/pony-kafka/custombuffered/_test.pony
@@ -69,7 +69,6 @@ class iso _TestIsoReader is UnitTest
     b.append(recover [as U8: '\n'; 't'; 'h'; 'e'] end)
     b.append(recover [as U8: 'r'; 'e'; '\r'; '\n'] end)
 
-
     // These expectations consume bytes from the head of the buffer.
     h.assert_eq[U8](LittleEndianDecoder.u8(b)?, 0x42)
     h.assert_eq[U16](BigEndianDecoder.u16(b)?, 0xDEAD)

--- a/pony-kafka/custombuffered/codecs/big_endian_decoder.pony
+++ b/pony-kafka/custombuffered/codecs/big_endian_decoder.pony
@@ -56,12 +56,17 @@ primitive BigEndianDecoder
     """
     let data = rb.read_bytes(2)?
 
-    _decode_u16(consume data)? as U16
+    _decode_u16(consume data)?
 
-  fun _decode_u16(data: Array[U8] val): U16 ? =>
-    (data(0)?.u16() << 8) or data(1)?.u16()
+  fun _decode_u16(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(0)?.u16() << 8) or d(1)?.u16()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u16_array(d)?
+    end
 
-  fun _decode_u16(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
+  fun _decode_u16_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
     var out: U16 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -78,7 +83,7 @@ primitive BigEndianDecoder
     while iter_all.has_next() do
       out = (out << 8) or iter_all.next()?.u16()
     end
-    return out
+    out
 
   fun i16(rb: Reader): I16 ? =>
     """
@@ -92,13 +97,18 @@ primitive BigEndianDecoder
     """
     let data = rb.read_bytes(4)?
 
-    _decode_u32(consume data)? as U32
+    _decode_u32(consume data)?
 
-  fun _decode_u32(data: Array[U8] val): U32 ? =>
-    (data(0)?.u32() << 24) or (data(1)?.u32() << 16) or
-    (data(2)?.u32() << 8) or data(3)?.u32()
+  fun _decode_u32(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(0)?.u32() << 24) or (d(1)?.u32() << 16) or
+      (d(2)?.u32() << 8) or d(3)?.u32()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u32_array(d)?
+    end
 
-  fun _decode_u32(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
+  fun _decode_u32_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
     var out: U32 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -115,7 +125,7 @@ primitive BigEndianDecoder
     while iter_all.has_next() do
       out = (out << 8) or iter_all.next()?.u32()
     end
-    return out
+    out
 
   fun i32(rb: Reader): I32 ? =>
     """
@@ -129,15 +139,20 @@ primitive BigEndianDecoder
     """
     let data = rb.read_bytes(8)?
 
-    _decode_u64(consume data)? as U64
+    _decode_u64(consume data)?
 
-  fun _decode_u64(data: Array[U8] val): U64 ? =>
-    (data(0)?.u64() << 56) or (data(1)?.u64() << 48) or
-    (data(2)?.u64() << 40) or (data(3)?.u64() << 32) or
-    (data(4)?.u64() << 24) or (data(5)?.u64() << 16) or
-    (data(6)?.u64() << 8) or data(7)?.u64()
+  fun _decode_u64(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(0)?.u64() << 56) or (d(1)?.u64() << 48) or
+      (d(2)?.u64() << 40) or (d(3)?.u64() << 32) or
+      (d(4)?.u64() << 24) or (d(5)?.u64() << 16) or
+      (d(6)?.u64() << 8) or d(7)?.u64()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u64_array(d)?
+    end
 
-  fun _decode_u64(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
+  fun _decode_u64_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
     var out: U64 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -154,7 +169,7 @@ primitive BigEndianDecoder
     while iter_all.has_next() do
       out = (out << 8) or iter_all.next()?.u64()
     end
-    return out
+    out
 
   fun i64(rb: Reader): I64 ? =>
     """
@@ -169,19 +184,24 @@ primitive BigEndianDecoder
     """
     let data = rb.read_bytes(16)?
 
-    _decode_u128(consume data)? as U128
+    _decode_u128(consume data)?
 
-  fun _decode_u128(data: Array[U8] val): U128 ? =>
-    (data(0)?.u128() << 120) or (data(1)?.u128() << 112) or
-    (data(2)?.u128() << 104) or (data(3)?.u128() << 96) or
-    (data(4)?.u128() << 88) or (data(5)?.u128() << 80) or
-    (data(6)?.u128() << 72) or (data(7)?.u128() << 64) or
-    (data(8)?.u128() << 56) or (data(9)?.u128() << 48) or
-    (data(10)?.u128() << 40) or (data(11)?.u128() << 32) or
-    (data(12)?.u128() << 24) or (data(13)?.u128() << 16) or
-    (data(14)?.u128() << 8) or data(15)?.u128()
+  fun _decode_u128(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(0)?.u128() << 120) or (d(1)?.u128() << 112) or
+      (d(2)?.u128() << 104) or (d(3)?.u128() << 96) or
+      (d(4)?.u128() << 88) or (d(5)?.u128() << 80) or
+      (d(6)?.u128() << 72) or (d(7)?.u128() << 64) or
+      (d(8)?.u128() << 56) or (d(9)?.u128() << 48) or
+      (d(10)?.u128() << 40) or (d(11)?.u128() << 32) or
+      (d(12)?.u128() << 24) or (d(13)?.u128() << 16) or
+      (d(14)?.u128() << 8) or d(15)?.u128()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u128_array(d)?
+    end
 
-  fun _decode_u128(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
+  fun _decode_u128_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
     var out: U128 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -198,7 +218,7 @@ primitive BigEndianDecoder
     while iter_all.has_next() do
       out = (out << 8) or iter_all.next()?.u128()
     end
-    return out
+    out
 
   fun i128(rb: Reader): I128 ? =>
     """
@@ -237,7 +257,7 @@ primitive BigEndianDecoder
     """
     let data = rb.peek_bytes(2, offset)?
 
-    _decode_u16(data)? as U16
+    _decode_u16(data)?
 
   fun peek_i16(rb: PeekableReader box, offset: USize = 0): I16 ? =>
     """
@@ -251,7 +271,7 @@ primitive BigEndianDecoder
     """
     let data = rb.peek_bytes(4, offset)?
 
-    _decode_u32(data)? as U32
+    _decode_u32(data)?
 
   fun peek_i32(rb: PeekableReader box, offset: USize = 0): I32 ? =>
     """
@@ -265,7 +285,7 @@ primitive BigEndianDecoder
     """
     let data = rb.peek_bytes(8, offset)?
 
-    _decode_u64(data)? as U64
+    _decode_u64(data)?
 
   fun peek_i64(rb: PeekableReader box, offset: USize = 0): I64 ? =>
     """
@@ -279,7 +299,7 @@ primitive BigEndianDecoder
     """
     let data = rb.peek_bytes(16, offset)?
 
-    _decode_u128(data)? as U128
+    _decode_u128(data)?
 
   fun peek_i128(rb: PeekableReader box, offset: USize = 0): I128 ? =>
     """

--- a/pony-kafka/custombuffered/codecs/little_endian_decoder.pony
+++ b/pony-kafka/custombuffered/codecs/little_endian_decoder.pony
@@ -56,12 +56,17 @@ primitive LittleEndianDecoder
     """
     let data = rb.read_bytes(2)?
 
-    _decode_u16(consume data)? as U16
+    _decode_u16(consume data)?
 
-  fun _decode_u16(data: Array[U8] val): U16 ? =>
-    (data(1)?.u16() << 8) or data(0)?.u16()
+  fun _decode_u16(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(1)?.u16() << 8) or d(0)?.u16()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u16_array(d)?
+    end
 
-  fun _decode_u16(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
+  fun _decode_u16_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U16 ? =>
     var out: U16 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -80,7 +85,7 @@ primitive LittleEndianDecoder
       out = out or (iter_all.next()?.u16() << (i * 8))
       i = i + 1
     end
-    return out
+    out
 
   fun i16(rb: Reader): I16 ? =>
     """
@@ -94,13 +99,18 @@ primitive LittleEndianDecoder
     """
     let data = rb.read_bytes(4)?
 
-    _decode_u32(consume data)? as U32
+    _decode_u32(consume data)?
 
-  fun _decode_u32(data: Array[U8] val): U32 ? =>
-    (data(3)?.u32() << 24) or (data(2)?.u32() << 16) or
-    (data(1)?.u32() << 8) or data(0)?.u32()
+  fun _decode_u32(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(3)?.u32() << 24) or (d(2)?.u32() << 16) or
+      (d(1)?.u32() << 8) or d(0)?.u32()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u32_array(d)?
+    end
 
-  fun _decode_u32(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
+  fun _decode_u32_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U32 ? =>
     var out: U32 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -119,7 +129,7 @@ primitive LittleEndianDecoder
       out = out or (iter_all.next()?.u32() << (i * 8))
       i = i + 1
     end
-    return out
+    out
 
   fun i32(rb: Reader): I32 ? =>
     """
@@ -133,15 +143,20 @@ primitive LittleEndianDecoder
     """
     let data = rb.read_bytes(8)?
 
-    _decode_u64(consume data)? as U64
+    _decode_u64(consume data)?
 
-  fun _decode_u64(data: Array[U8] val): U64 ? =>
-    (data(7)?.u64() << 56) or (data(6)?.u64() << 48) or
-    (data(5)?.u64() << 40) or (data(4)?.u64() << 32) or
-    (data(3)?.u64() << 24) or (data(2)?.u64() << 16) or
-    (data(1)?.u64() << 8) or data(0)?.u64()
+  fun _decode_u64(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(7)?.u64() << 56) or (d(6)?.u64() << 48) or
+      (d(5)?.u64() << 40) or (d(4)?.u64() << 32) or
+      (d(3)?.u64() << 24) or (d(2)?.u64() << 16) or
+      (d(1)?.u64() << 8) or d(0)?.u64()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u64_array(d)?
+    end
 
-  fun _decode_u64(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
+  fun _decode_u64_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U64 ? =>
     var out: U64 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -160,7 +175,7 @@ primitive LittleEndianDecoder
       out = out or (iter_all.next()?.u64() << (i * 8))
       i = i + 1
     end
-    return out
+    out
 
   fun i64(rb: Reader): I64 ? =>
     """
@@ -174,19 +189,24 @@ primitive LittleEndianDecoder
     """
     let data = rb.read_bytes(16)?
 
-    _decode_u128(consume data)? as U128
+    _decode_u128(consume data)?
 
-  fun _decode_u128(data: Array[U8] val): U128 ? =>
-    (data(15)?.u128() << 120) or (data(14)?.u128() << 112) or
-    (data(13)?.u128() << 104) or (data(12)?.u128() << 96) or
-    (data(11)?.u128() << 88) or (data(10)?.u128() << 80) or
-    (data(9)?.u128() << 72) or (data(8)?.u128() << 64) or
-    (data(7)?.u128() << 56) or (data(6)?.u128() << 48) or
-    (data(5)?.u128() << 40) or (data(4)?.u128() << 32) or
-    (data(3)?.u128() << 24) or (data(2)?.u128() << 16) or
-    (data(1)?.u128() << 8) or data(0)?.u128()
+  fun _decode_u128(data: (Array[U8] val | Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
+    match data
+    | let d: Array[U8] val =>
+      (d(15)?.u128() << 120) or (d(14)?.u128() << 112) or
+      (d(13)?.u128() << 104) or (d(12)?.u128() << 96) or
+      (d(11)?.u128() << 88) or (d(10)?.u128() << 80) or
+      (d(9)?.u128() << 72) or (d(8)?.u128() << 64) or
+      (d(7)?.u128() << 56) or (d(6)?.u128() << 48) or
+      (d(5)?.u128() << 40) or (d(4)?.u128() << 32) or
+      (d(3)?.u128() << 24) or (d(2)?.u128() << 16) or
+      (d(1)?.u128() << 8) or d(0)?.u128()
+    | let d: (Array[Array[U8] val] val | Array[Array[U8] iso] val) =>
+      _decode_u128_array(d)?
+    end
 
-  fun _decode_u128(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
+  fun _decode_u128_array(data: (Array[Array[U8] val] val | Array[Array[U8] iso] val)): U128 ? =>
     var out: U128 = 0
     let iters = Array[Iterator[U8]]
     match data
@@ -205,7 +225,7 @@ primitive LittleEndianDecoder
       out = out or (iter_all.next()?.u128() << (i * 8))
       i = i + 1
     end
-    return out
+    out
 
   fun i128(rb: Reader): I128 ? =>
     """
@@ -244,7 +264,7 @@ primitive LittleEndianDecoder
     """
     let data = rb.peek_bytes(2, offset)?
 
-    _decode_u16(data)? as U16
+    _decode_u16(data)?
 
   fun peek_i16(rb: PeekableReader, offset: USize = 0): I16 ? =>
     """
@@ -258,7 +278,7 @@ primitive LittleEndianDecoder
     """
     let data = rb.peek_bytes(4, offset)?
 
-    _decode_u32(data)? as U32
+    _decode_u32(data)?
 
   fun peek_i32(rb: PeekableReader, offset: USize = 0): I32 ? =>
     """
@@ -272,7 +292,7 @@ primitive LittleEndianDecoder
     """
     let data = rb.peek_bytes(8, offset)?
 
-    _decode_u64(data)? as U64
+    _decode_u64(data)?
 
   fun peek_i64(rb: PeekableReader, offset: USize = 0): I64 ? =>
     """
@@ -286,7 +306,7 @@ primitive LittleEndianDecoder
     """
     let data = rb.peek_bytes(16, offset)?
 
-    _decode_u128(data)? as U128
+    _decode_u128(data)?
 
   fun peek_i128(rb: PeekableReader, offset: USize = 0): I128 ? =>
     """

--- a/pony-kafka/custombuffered/iso_reader.pony
+++ b/pony-kafka/custombuffered/iso_reader.pony
@@ -160,6 +160,7 @@ class IsoReader is Reader
       error
     end
 
+    // TODO: rewrite to avoid allocation of out array if all data if in first chunk
     _available = _available - len
     var out = recover Array[Array[U8] iso] end
     var i = USize(0)
@@ -172,8 +173,11 @@ class IsoReader is Reader
 
       (let next_segment, data) = (consume data).chop(need)
 
-      if avail > need then
-        _chunks.unshift(consume data)
+      if avail >= need then
+        if data.size() > 0 then
+          _chunks.unshift(consume data)
+        end
+
         if out.size() == 0 then
           return (copy_len, consume next_segment)
         else

--- a/pony-kafka/custombuffered/val_reader.pony
+++ b/pony-kafka/custombuffered/val_reader.pony
@@ -108,7 +108,7 @@ class ValReader is PeekableReader
     _chunks.clear()
     _available = 0
 
-  fun ref append(data: ByteSeq) =>
+  fun ref _append(data: ByteSeq) =>
     """
     Add a chunk of data.
     """
@@ -121,14 +121,18 @@ class ValReader is PeekableReader
     _available = _available + data_array.size()
     _chunks.push((data_array, 0))
 
-  fun ref append(data: Array[ByteSeq] val) =>
+  fun ref append(data: (ByteSeq | Array[ByteSeq] val)) =>
     """
     Add a chunk of data.
     """
-    for d in data.values() do
-      match d
-      | let s: String => append(s.array())
-      | let a: Array[U8] val => append(a)
+    match data
+    | let data': ByteSeq => _append(data')
+    | let data': Array[ByteSeq] val =>
+      for d in data'.values() do
+        match d
+        | let s: String => append(s.array())
+        | let a: Array[U8] val => append(a)
+        end
       end
     end
 

--- a/pony-kafka/kafka_api.pony
+++ b/pony-kafka/kafka_api.pony
@@ -241,8 +241,8 @@ class ProducerKafkaMessage
 
   fun val _get_created_by(): KafkaProducer tag => _created_by
 
-  fun val _send_delivery_report(delivery_report: KafkaProducerDeliveryReport) =>
-    _created_by.kafka_message_delivery_report(delivery_report)
+  fun val _send_delivery_report(client: KafkaClient, delivery_report: KafkaProducerDeliveryReport) =>
+    _created_by.kafka_message_delivery_report(client, delivery_report)
 
 type KafkaMessageOrError is (Array[U8] iso, (Array[U8] iso | None | KafkaError), KafkaMessageMetadata iso)
 

--- a/pony-kafka/kafka_broker_connection.pony
+++ b/pony-kafka/kafka_broker_connection.pony
@@ -86,10 +86,10 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler)._consumer_pause_all(this)
     end
 
-  be _consumer_resume(topic: String, partition_id: KafkaPartitionId) =>
+  be _consumer_resume(topic: String, partition_id: KafkaPartitionId, offset: KafkaOffset = -999) =>
     try
       ((get_handler() as CustomTCPConnectionHandler).notify as
-        _KafkaHandler)._consumer_resume(this, topic, partition_id)
+        _KafkaHandler)._consumer_resume(this, topic, partition_id, offset)
     end
 
   be _consumer_resume_all() =>

--- a/pony-kafka/kafka_broker_connection.pony
+++ b/pony-kafka/kafka_broker_connection.pony
@@ -24,7 +24,7 @@ use "collections"
 // connection
 trait KafkaBrokerConnection is CustomTCPConnection
   // behavior to update the internal brokers list
-  be _update_brokers_list(brokers_list: Map[I32, (_KafkaBroker val,
+  be _update_brokers_list(brokers_list: Map[KafkaNodeId, (_KafkaBroker val,
     KafkaBrokerConnection tag)] val)
   =>
     try
@@ -33,7 +33,7 @@ trait KafkaBrokerConnection is CustomTCPConnection
     end
 
   // behavior to send messages to kafka brokers
-  be send_kafka_messages(topic: String, msgs_to_send: Map[I32,
+  be send_kafka_messages(topic: String, msgs_to_send: Map[KafkaPartitionId,
     Array[ProducerKafkaMessage val] iso] val, auth: _KafkaProducerAuth)
   =>
     try
@@ -41,7 +41,7 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler).send_kafka_messages(this, topic, msgs_to_send, auth)?
     end
 
-  be send_kafka_message(topic: String, partition_id: I32,
+  be send_kafka_message(topic: String, partition_id: KafkaPartitionId,
     msg_to_send: ProducerKafkaMessage val, auth: _KafkaProducerAuth)
   =>
     try
@@ -74,7 +74,7 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler)._update_consumers(topic_consumers)
     end
 
-  be _consumer_pause(topic: String, partition_id: I32) =>
+  be _consumer_pause(topic: String, partition_id: KafkaPartitionId) =>
     try
       ((get_handler() as CustomTCPConnectionHandler).notify as
         _KafkaHandler)._consumer_pause(this, topic, partition_id)
@@ -86,7 +86,7 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler)._consumer_pause_all(this)
     end
 
-  be _consumer_resume(topic: String, partition_id: I32) =>
+  be _consumer_resume(topic: String, partition_id: KafkaPartitionId) =>
     try
       ((get_handler() as CustomTCPConnectionHandler).notify as
         _KafkaHandler)._consumer_resume(this, topic, partition_id)
@@ -116,7 +116,7 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler)._send_pending_messages(this)?
     end
 
-  be _leader_change_throttle_ack(topics_to_throttle: Map[String, Set[I32] iso]
+  be _leader_change_throttle_ack(topics_to_throttle: Map[String, Set[KafkaPartitionId] iso]
     val)
   =>
     try
@@ -131,8 +131,8 @@ trait KafkaBrokerConnection is CustomTCPConnection
         _KafkaHandler)._update_metadata(meta, this)
     end
 
-  be _leader_change_msgs(meta: _KafkaMetadata val, topic: String, partition_id: I32,
-    msgs: Map[I32, Array[ProducerKafkaMessage val] iso] val, request_offset: I64)
+  be _leader_change_msgs(meta: _KafkaMetadata val, topic: String, partition_id: KafkaPartitionId,
+    msgs: Map[KafkaPartitionId, Array[ProducerKafkaMessage val] iso] val, request_offset: KafkaOffset)
   =>
     try
       ((get_handler() as CustomTCPConnectionHandler).notify as

--- a/pony-kafka/kafka_config_cli_parser.pony
+++ b/pony-kafka/kafka_config_cli_parser.pony
@@ -377,11 +377,11 @@ primitive KafkaConfigFactory
           // if no default, throw an error
           error
         end
-      | let s: String => s.i32()?
+      | let s: String => s.i64()?
       end
 
-  fun _parse_partitions(partitions: String, offset_default: ConsumerRequestOffset): Array[(I32, ConsumerRequestOffset)] val ? =>
-    let partitions_offsets = recover trn Array[(I32, ConsumerRequestOffset)] end
+  fun _parse_partitions(partitions: String, offset_default: ConsumerRequestOffset): Array[(KafkaPartitionId, ConsumerRequestOffset)] val ? =>
+    let partitions_offsets = recover trn Array[(KafkaPartitionId, ConsumerRequestOffset)] end
 
     for part in partitions.split(",").values() do
       let i = part.split(":")

--- a/pony-kafka/kafka_config_cli_parser.pony
+++ b/pony-kafka/kafka_config_cli_parser.pony
@@ -129,7 +129,7 @@ class KafkaConfigCLIParser
              | F64Argument => "(Float)"
              else "" end
 
-      _out.print("--" + long + short_str + "       " + arg_type_str + "    "
+      _out.print("  --" + long + short_str + "       " + arg_type_str + "    "
         + help)
     end
 

--- a/pony-kafka/kafka_errors.pony
+++ b/pony-kafka/kafka_errors.pony
@@ -20,14 +20,14 @@ limitations under the License.
 use "customlogger"
 
 trait val KafkaError
-  fun apply(): I16
+  fun apply(): KafkaApiError
   fun string(): String
   fun kafka_official(): Bool
   fun _retriable(): Bool
 
 
 primitive MapKafkaError
-  fun apply(logger: Logger[String], error_code: I16): KafkaError =>
+  fun apply(logger: Logger[String], error_code: KafkaApiError): KafkaError =>
     match (error_code)
     | ErrorNone() => ErrorNone
     | ErrorUnknown() => ErrorUnknown
@@ -96,6 +96,8 @@ primitive MapKafkaError
     end
 
 
+// TODO: Does this class mean that the match in MapKafkaError creates a new object each time?
+//       if yes, need to fix so that doesn't happen all the time
 class val ClientErrorShouldNeverHappen is KafkaError
   let details: String
 
@@ -105,7 +107,7 @@ class val ClientErrorShouldNeverHappen is KafkaError
     let file_linepos: String  = loc.pos().string()
     details = message + " - " + file_name + ":" + file_linenum + ":" + file_linepos
 
-  fun apply(): I16 => -9000
+  fun apply(): KafkaApiError => -9000
   fun string(): String => "Client(ClientErrorShouldNeverHappen/" + apply().string() +
     "): This should never happen. " + details
   fun kafka_official(): Bool => false
@@ -120,35 +122,35 @@ class val ClientErrorDecode is KafkaError
     let file_linepos: String  = loc.pos().string()
     details = message + " - " + file_name + ":" + file_linenum + ":" + file_linepos
 
-  fun apply(): I16 => -9001
+  fun apply(): KafkaApiError => -9001
   fun string(): String => "Client(ClientErrorDecode/" + apply().string() +
     "): Error decoding data. " + details
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorPartitionFail is KafkaError
-  fun apply(): I16 => -9002
+  fun apply(): KafkaApiError => -9002
   fun string(): String => "Client(ClientErrorPartitionFail/" + apply().string() +
     "): Partition requested doesn't exist in kafka."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorInvalidPartition is KafkaError
-  fun apply(): I16 => -9003
+  fun apply(): KafkaApiError => -9003
   fun string(): String => "Client(ClientErrorInvalidPartition/" + apply().string() +
     "): Invalid Partition assigned by producer message handler."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorProducerTopicNotRegistered is KafkaError
-  fun apply(): I16 => -9004
+  fun apply(): KafkaApiError => -9004
   fun string(): String => "Client(ClientErrorProducerTopicNotRegistered/" + apply().string() +
     "): Topic for producing not registered in config."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorMessageTooLarge is KafkaError
-  fun apply(): I16 => -9005
+  fun apply(): KafkaApiError => -9005
   fun string(): String => "Client(ClientErrorMessageTooLarge/" + apply().string() + "): The request " +
     "included a message larger than the max message size the client is " +
     "configured to handle."
@@ -156,7 +158,7 @@ primitive ClientErrorMessageTooLarge is KafkaError
   fun _retriable(): Bool => false
 
 primitive ClientErrorNoBuffering is KafkaError
-  fun apply(): I16 => -9006
+  fun apply(): KafkaApiError => -9006
   fun string(): String => "Client(ClientErrorNoBuffering/" + apply().string() +
     "): Topic/partition is throttled and KafkaClient hasn't implemented " +
     "buffering yet."
@@ -164,42 +166,42 @@ primitive ClientErrorNoBuffering is KafkaError
   fun _retriable(): Bool => true
 
 primitive ClientErrorCorrelationIdMismatch is KafkaError
-  fun apply(): I16 => -9007
+  fun apply(): KafkaApiError => -9007
   fun string(): String => "Client(ClientErrorCorrelationIdMismatch/" + apply().string() +
     "): Correlation ID from Broker doesn't match expected Correlation ID."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorUnknownRequest is KafkaError
-  fun apply(): I16 => -9008
+  fun apply(): KafkaApiError => -9008
   fun string(): String => "Client(ClientErrorUnknownRequest/" + apply().string() +
     "): Unknown request type for response."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorUnableToLookupBroker is KafkaError
-  fun apply(): I16 => -9009
+  fun apply(): KafkaApiError => -9009
   fun string(): String => "Client(ClientErrorUnableToLookupBroker/" + apply().string() +
     "): Unable to lookup broker id to send message to."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorDecodingMetadataResponse is KafkaError
-  fun apply(): I16 => -9010
+  fun apply(): KafkaApiError => -9010
   fun string(): String => "Client(ClientErrorDecodingMetadataResponse/" + apply().string() +
     "): Error decoding metadata response."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorInitilizingConnection is KafkaError
-  fun apply(): I16 => -9011
+  fun apply(): KafkaApiError => -9011
   fun string(): String => "Client(ClientErrorInitilizingConnection/" + apply().string() +
     "): Error initializing connection."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorInitializingFSM is KafkaError
-  fun apply(): I16 => -9012
+  fun apply(): KafkaApiError => -9012
   fun string(): String => "Client(ClientErrorInitializingFSM/" + apply().string() +
     "): Error initializing state machine."
   fun kafka_official(): Bool => false
@@ -214,66 +216,66 @@ class val ClientErrorTransitioningFSMStates is KafkaError
     let file_linepos: String  = loc.pos().string()
     details = message + " - " + file_name + ":" + file_linenum + ":" + file_linepos
 
-  fun apply(): I16 => -9013
+  fun apply(): KafkaApiError => -9013
   fun string(): String => "Client(ClientErrorTransitioningFSMStates/" + apply().string() +
     "): Error transitioning states in state machine." + details
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorCorruptMessage is KafkaError
-  fun apply(): I16 => -9014
+  fun apply(): KafkaApiError => -9014
   fun string(): String => "Client(ClientErrorCorruptMessage/" + apply().string() + "): This message has" +
     " failed its CRC checksum."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorNoZlib is KafkaError
-  fun apply(): I16 => -9015
+  fun apply(): KafkaApiError => -9015
   fun string(): String => "Client(ClientErrorNoZlib/" + apply().string() + "): GZip/Zlib compression support " +
     "not compiled."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorGZipDecompress is KafkaError
-  fun apply(): I16 => -9016
+  fun apply(): KafkaApiError => -9016
   fun string(): String => "Client(ClientErrorGZipDecompress/" + apply().string() + "): Gzip decompression error!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorNoSnappy is KafkaError
-  fun apply(): I16 => -9017
+  fun apply(): KafkaApiError => -9017
   fun string(): String => "Client(ClientErrorNoSnappy/" + apply().string() + "): Snappy compression support not " +
           "compiled."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorSnappyDecompress is KafkaError
-  fun apply(): I16 => -9018
+  fun apply(): KafkaApiError => -9018
   fun string(): String => "Client(ClientErrorSnappyDecompress/" + apply().string() + "): Snappy decompression error!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorNoLZ4 is KafkaError
-  fun apply(): I16 => -9019
+  fun apply(): KafkaApiError => -9019
   fun string(): String => "Client(ClientErrorNoLZ4/" + apply().string() + "): LZ4 compression support not " +
           "compiled."
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorLZ4Decompress is KafkaError
-  fun apply(): I16 => -9020
+  fun apply(): KafkaApiError => -9020
   fun string(): String => "Client(ClientErrorLZ4Decompress/" + apply().string() + "): LZ4 decompression error!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorUnknownCompression is KafkaError
-  fun apply(): I16 => -9021
+  fun apply(): KafkaApiError => -9021
   fun string(): String => "Client(ClientErrorUnknownCompression/" + apply().string() + "): Unknown compression format encountered!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ClientErrorNoConnection is KafkaError
-  fun apply(): I16 => -9022
+  fun apply(): KafkaApiError => -9022
   fun string(): String => "Client(ClientErrorNoConnection/" + apply().string() + "): No connection! Ran out of reconnect attempts!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
@@ -284,54 +286,54 @@ class val ClientErrorNoBrokerConnection is KafkaError
   new val create(broker_tag': KafkaBrokerConnection tag) =>
     broker_tag = broker_tag'
 
-  fun apply(): I16 => -9023
+  fun apply(): KafkaApiError => -9023
   fun string(): String => "Client(ClientErrorNoBrokerConnection/" + apply().string() + "): No broker connection! Ran out of reconnect attempts!"
   fun kafka_official(): Bool => false
   fun _retriable(): Bool => false
 
 primitive ErrorNone is KafkaError
-  fun apply(): I16 => 0
+  fun apply(): KafkaApiError => 0
   fun string(): String => apply().string() + ": Success (no error)."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorUnknown is KafkaError
-  fun apply(): I16 => -1
+  fun apply(): KafkaApiError => -1
   fun string(): String => "Broker(ErrorUnknown/" + apply().string() +
     "): The server experienced an unexpected error when processing the request."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorOffsetOutOfRange is KafkaError
-  fun apply(): I16 => 1
+  fun apply(): KafkaApiError => 1
   fun string(): String => "Broker(ErrorOffsetOutOfRange/" + apply().string() + "): The requested " +
     "offset is not within the range of offsets maintained by the server."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorCorruptMessage is KafkaError
-  fun apply(): I16 => 2
+  fun apply(): KafkaApiError => 2
   fun string(): String => "Broker(ErrorCorruptMessage/" + apply().string() + "): This message has" +
     " failed its CRC checksum, exceeds the valid size, or is otherwise corrupt."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorUnknownTopicOrPartition is KafkaError
-  fun apply(): I16 => 3
+  fun apply(): KafkaApiError => 3
   fun string(): String => "Broker(ErrorUnknownTopicOrPartition/" + apply().string() +
     "): This server does not host this topic-partition."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorInvalidFetchSize is KafkaError
-  fun apply(): I16 => 4
+  fun apply(): KafkaApiError => 4
   fun string(): String => "Broker(ErrorInvalidFetchSize/" + apply().string() +
     "): The requested fetch size is invalid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorLeaderNotAvailable is KafkaError
-  fun apply(): I16 => 5
+  fun apply(): KafkaApiError => 5
   fun string(): String => "Broker(ErrorLeaderNotAvailable/" + apply().string() + "): There is no " +
     "leader for this topic-partition as we are in the middle of a leadership " +
     "election."
@@ -339,35 +341,35 @@ primitive ErrorLeaderNotAvailable is KafkaError
   fun _retriable(): Bool => true
 
 primitive ErrorNotLeaderForPartition is KafkaError
-  fun apply(): I16 => 6
+  fun apply(): KafkaApiError => 6
   fun string(): String => "Broker(ErrorNotLeaderForPartition/" + apply().string() + "): This server is " +
     "not the leader for that topic-partition."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorRequestTimedOut is KafkaError
-  fun apply(): I16 => 7
+  fun apply(): KafkaApiError => 7
   fun string(): String => "Broker(ErrorRequestTimedOut/" + apply().string() +
     "): The request timed out."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorBrokerNotAvailable is KafkaError
-  fun apply(): I16 => 8
+  fun apply(): KafkaApiError => 8
   fun string(): String => "Broker(ErrorBrokerNotAvailable/" + apply().string() +
     "): The broker is not available."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorReplicaNotAvailable is KafkaError
-  fun apply(): I16 => 9
+  fun apply(): KafkaApiError => 9
   fun string(): String => "Broker(ErrorReplicaNotAvailable/" + apply().string() +
     "): The replica is not available for the requested topic-partition"
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorMessageTooLarge is KafkaError
-  fun apply(): I16 => 10
+  fun apply(): KafkaApiError => 10
   fun string(): String => "Broker(ErrorMessageTooLarge/" + apply().string() + "): The request " +
     "included a message larger than the max message size the server will " +
     "accept."
@@ -375,56 +377,56 @@ primitive ErrorMessageTooLarge is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorStaleControllerEpoch is KafkaError
-  fun apply(): I16 => 11
+  fun apply(): KafkaApiError => 11
   fun string(): String => "Broker(ErrorStaleControllerEpoch/" + apply().string() +
     "): The controller moved to another broker."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorOffsetMetadataTooLarge is KafkaError
-  fun apply(): I16 => 12
+  fun apply(): KafkaApiError => 12
   fun string(): String => "Broker(ErrorOffsetMetadataTooLarge/" + apply().string() +
     "): The metadata field of the offset request was too large."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorNetworkException is KafkaError
-  fun apply(): I16 => 13
+  fun apply(): KafkaApiError => 13
   fun string(): String => "Broker(ErrorNetworkException/" + apply().string() +
     "): The server disconnected before a response was received."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorGroupLoadInProgress is KafkaError
-  fun apply(): I16 => 14
+  fun apply(): KafkaApiError => 14
   fun string(): String => "Broker(ErrorGroupLoadInProgress/" + apply().string() + "): The group " +
     "coordinator is loading and hence can't process requests for this group."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorGroupCoordinatorNotAvailable is KafkaError
-  fun apply(): I16 => 15
+  fun apply(): KafkaApiError => 15
   fun string(): String => "Broker(ErrorGroupCoordinatorNotAvailable/" + apply().string() +
     "): The group coordinator is not available."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorNotCoordinatorForGroup is KafkaError
-  fun apply(): I16 => 16
+  fun apply(): KafkaApiError => 16
   fun string(): String => "Broker(ErrorNotCoordinatorForGroup/" + apply().string() +
     "): This is not the correct coordinator for this group."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorInvalidTopicException is KafkaError
-  fun apply(): I16 => 17
+  fun apply(): KafkaApiError => 17
   fun string(): String => "Broker(ErrorInvalidTopicException/" + apply().string() +
     "): The request attempted to perform an operation on an invalid topic."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorRecordListTooLarge is KafkaError
-  fun apply(): I16 => 18
+  fun apply(): KafkaApiError => 18
   fun string(): String => "Broker(ErrorRecordListTooLarge/" + apply().string() + "): The request " +
     "included message batch larger than the configured segment size on the " +
     "server."
@@ -432,35 +434,35 @@ primitive ErrorRecordListTooLarge is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorNotEnoughReplicas is KafkaError
-  fun apply(): I16 => 19
+  fun apply(): KafkaApiError => 19
   fun string(): String => "Broker(ErrorNotEnoughReplicas/" + apply().string() + "): Messages are " +
     "rejected since there are fewer in-sync replicas than required."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorNotEnoughReplicasAfterAppend is KafkaError
-  fun apply(): I16 => 20
+  fun apply(): KafkaApiError => 20
   fun string(): String => "Broker(ErrorNotEnoughReplicasAfterAppend/" + apply().string() + "): Messages are " +
     "written to the log, but to fewer in-sync replicas than required."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorInvalidRequiredAcks is KafkaError
-  fun apply(): I16 => 21
+  fun apply(): KafkaApiError => 21
   fun string(): String => "Broker(ErrorInvalidRequiredAcks/" + apply().string() +
     "): Produce request specified an invalid value for required acks."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorIllegalGeneration is KafkaError
-  fun apply(): I16 => 22
+  fun apply(): KafkaApiError => 22
   fun string(): String => "Broker(ErrorIllegalGeneration/" + apply().string() +
     "): Specified group generation id is not valid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInconsistentGroupProtocol is KafkaError
-  fun apply(): I16 => 23
+  fun apply(): KafkaApiError => 23
   fun string(): String => "Broker(ErrorInconsistentGroupProtocol/" + apply().string() + "): The group " +
     "member's supported protocols are incompatible with those of existing " +
     "members."
@@ -468,21 +470,21 @@ primitive ErrorInconsistentGroupProtocol is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidGroupId is KafkaError
-  fun apply(): I16 => 24
+  fun apply(): KafkaApiError => 24
   fun string(): String => "Broker(ErrorInvalidGroupId/" + apply().string() +
     "): The configured groupId is invalid"
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorUnknownMemberId is KafkaError
-  fun apply(): I16 => 25
+  fun apply(): KafkaApiError => 25
   fun string(): String => "Broker(ErrorUnknownMemberId/" + apply().string() +
     "): The coordinator is not aware of this member."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidSessionTimeout is KafkaError
-  fun apply(): I16 => 26
+  fun apply(): KafkaApiError => 26
   fun string(): String => "Broker(ErrorInvalidSessionTimeout/" + apply().string() + "): The session " +
     "timeout is not within the range allowed by the broker (as configured by " +
     "group.min.session.timeout.ms and group.max.session.timeout.ms)."
@@ -490,112 +492,112 @@ primitive ErrorInvalidSessionTimeout is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorRebalanceInProgress is KafkaError
-  fun apply(): I16 => 27
+  fun apply(): KafkaApiError => 27
   fun string(): String => "Broker(ErrorRebalanceInProgress/" + apply().string() +
     "): The group is rebalancing, so a rejoin is needed."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidCommitOffsetSize is KafkaError
-  fun apply(): I16 => 28
+  fun apply(): KafkaApiError => 28
   fun string(): String => "Broker(ErrorInvalidCommitOffsetSize/" + apply().string() +
     "): The committing offset data size is not valid"
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorTopicAuthorizationFailed is KafkaError
-  fun apply(): I16 => 29
+  fun apply(): KafkaApiError => 29
   fun string(): String => "Broker(ErrorTopicAuthorizationFailed/" + apply().string() +
     "): Not authorized to access topics: [Topic authorization failed.]"
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorGroupAuthorizationFailed is KafkaError
-  fun apply(): I16 => 30
+  fun apply(): KafkaApiError => 30
   fun string(): String => "Broker(ErrorGroupAuthorizationFailed/" + apply().string() +
     "): Not authorized to access group: Group authorization failed."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorClusterAuthorizationFailed is KafkaError
-  fun apply(): I16 => 31
+  fun apply(): KafkaApiError => 31
   fun string(): String => "Broker(ErrorClusterAuthorizationFailed/" + apply().string() +
     "): Cluster authorization failed."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidTimestamp is KafkaError
-  fun apply(): I16 => 32
+  fun apply(): KafkaApiError => 32
   fun string(): String => "Broker(ErrorInvalidTimestamp/" + apply().string() +
     "): The timestamp of the message is out of acceptable range."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorUnsupportedSASLMechanism is KafkaError
-  fun apply(): I16 => 33
+  fun apply(): KafkaApiError => 33
   fun string(): String => "Broker(ErrorUnsupportedSASLMechanism/" + apply().string() +
     "): The broker does not support the requested SASL mechanism."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorIllegalSASLState is KafkaError
-  fun apply(): I16 => 34
+  fun apply(): KafkaApiError => 34
   fun string(): String => "Broker(ErrorIllegalSASLState/" + apply().string() +
     "): Request is not valid given the current SASL state."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorUnsupportedVersion is KafkaError
-  fun apply(): I16 => 35
+  fun apply(): KafkaApiError => 35
   fun string(): String => "Broker(ErrorUnsupportedVersion/" + apply().string() +
     "): The version of API is not supported."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorTopicAlreadyExists is KafkaError
-  fun apply(): I16 => 36
+  fun apply(): KafkaApiError => 36
   fun string(): String => "Broker(ErrorTopicAlreadyExists/" + apply().string() +
     "): Topic with this name already exists."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidPartitions is KafkaError
-  fun apply(): I16 => 37
+  fun apply(): KafkaApiError => 37
   fun string(): String => "Broker(ErrorInvalidPartitions/" + apply().string() +
     "): Number of partitions is invalid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidReplicationFactor is KafkaError
-  fun apply(): I16 => 38
+  fun apply(): KafkaApiError => 38
   fun string(): String => "Broker(ErrorInvalidReplicationFactor/" + apply().string() +
     "): Replication-factor is invalid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidReplicaAssignment is KafkaError
-  fun apply(): I16 => 39
+  fun apply(): KafkaApiError => 39
   fun string(): String => "Broker(ErrorInvalidReplicaAssignment/" + apply().string() +
     "): Replica assignment is invalid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidConfig is KafkaError
-  fun apply(): I16 => 40
+  fun apply(): KafkaApiError => 40
   fun string(): String => "Broker(ErrorInvalidConfig/" + apply().string() +
     "): Configuration is invalid."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorNotController is KafkaError
-  fun apply(): I16 => 41
+  fun apply(): KafkaApiError => 41
   fun string(): String => "Broker(ErrorNotController/" + apply().string() +
     "): This is not the correct controller for this cluster."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorInvalidRequest is KafkaError
-  fun apply(): I16 => 42
+  fun apply(): KafkaApiError => 42
   fun string(): String => "Broker(ErrorInvalidRequest/" + apply().string() + "): This most " +
     "likely occurs because of a request being malformed by the client " +
     "library or the message was sent to an incompatible broker. See the " +
@@ -604,35 +606,35 @@ primitive ErrorInvalidRequest is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorUnsupportedForMessageFormat is KafkaError
-  fun apply(): I16 => 43
+  fun apply(): KafkaApiError => 43
   fun string(): String => "Broker(ErrorUnsupportedForMessageFormat/" + apply().string() +
     "): The message format version on the broker does not support the request."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorPolicyViolation is KafkaError
-  fun apply(): I16 => 44
+  fun apply(): KafkaApiError => 44
   fun string(): String => "Broker(ErrorPolicyViolation/" + apply().string() +
     "): Request parameters do not satisfy the configured policy."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorOutOfOrderSequenceNumber is KafkaError
-  fun apply(): I16 => 45
+  fun apply(): KafkaApiError => 45
   fun string(): String => "Broker(ErrorOutOfOrderSequenceNumber/" + apply().string() +
     "): The broker received an out of order sequence number."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorDuplicateSequenceNumber is KafkaError
-  fun apply(): I16 => 46
+  fun apply(): KafkaApiError => 46
   fun string(): String => "Broker(ErrorDuplicateSequenceNumber/" + apply().string() +
     "): The broker received a duplicate sequence number."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => true
 
 primitive ErrorInvalidProducerEpoch is KafkaError
-  fun apply(): I16 => 47
+  fun apply(): KafkaApiError => 47
   fun string(): String => "Broker(ErrorInvalidProducerEpoch/" + apply().string() + "): Producer " +
     "attempted an operation with an old epoch. Either there is a newer " +
     "producer with the same transactionalId, or the producer's transaction " +
@@ -641,14 +643,14 @@ primitive ErrorInvalidProducerEpoch is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidTxnState is KafkaError
-  fun apply(): I16 => 48
+  fun apply(): KafkaApiError => 48
   fun string(): String => "Broker(ErrorInvalidTxnState/" + apply().string() +
     "): The producer attempted a transactional operation in an invalid state."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidProducerIdMapping is KafkaError
-  fun apply(): I16 => 49
+  fun apply(): KafkaApiError => 49
   fun string(): String => "Broker(ErrorInvalidProducerIdMapping/" + apply().string() + "): The producer " +
     "attempted to use a producer id which is not currently assigned to its " +
     "transactional id."
@@ -656,7 +658,7 @@ primitive ErrorInvalidProducerIdMapping is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorInvalidTransactionTimeout is KafkaError
-  fun apply(): I16 => 50
+  fun apply(): KafkaApiError => 50
   fun string(): String => "Broker(ErrorInvalidTransactionTimeout/" + apply().string() + "): The transaction " +
     "timeout is larger than the maximum value allowed by the broker (as " +
     "configured by max.transaction.timeout.ms)."
@@ -664,7 +666,7 @@ primitive ErrorInvalidTransactionTimeout is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorConcurrentTransactions is KafkaError
-  fun apply(): I16 => 51
+  fun apply(): KafkaApiError => 51
   fun string(): String => "Broker(ErrorConcurrentTransactions/" + apply().string() + "): The producer " +
     "attempted to update a transaction while another concurrent operation on " +
     "the same transaction was ongoing."
@@ -672,7 +674,7 @@ primitive ErrorConcurrentTransactions is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorTransactionCoordinatorFenced is KafkaError
-  fun apply(): I16 => 52
+  fun apply(): KafkaApiError => 52
   fun string(): String => "Broker(ErrorTransactionCoordinatorFenced/" + apply().string() + "): Indicates that " +
     "the transaction coordinator sending a WriteTxnMarker is no longer the " +
     "current coordinator for a given producer."
@@ -680,14 +682,14 @@ primitive ErrorTransactionCoordinatorFenced is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorTransactionalIdAuthorizationFailed is KafkaError
-  fun apply(): I16 => 53
+  fun apply(): KafkaApiError => 53
   fun string(): String => "Broker(ErrorTransactionalIdAuthorizationFailed/" + apply().string() +
     "): Transactional Id authorization failed."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorProducerIdAuthorizationFailed is KafkaError
-  fun apply(): I16 => 54
+  fun apply(): KafkaApiError => 54
   fun string(): String => "Broker(ErrorProducerIdAuthorizationFailed/" + apply().string() + "): Producer is not " +
     "authorized to use producer Ids, which is required to write idempotent " +
     "data."
@@ -695,14 +697,14 @@ primitive ErrorProducerIdAuthorizationFailed is KafkaError
   fun _retriable(): Bool => false
 
 primitive ErrorSecurityDisabled is KafkaError
-  fun apply(): I16 => 55
+  fun apply(): KafkaApiError => 55
   fun string(): String => "Broker(ErrorSecurityDisabled/" + apply().string() +
     "): Security features are disabled."
   fun kafka_official(): Bool => true
   fun _retriable(): Bool => false
 
 primitive ErrorBrokerAuthorizationFailed is KafkaError
-  fun apply(): I16 => 56
+  fun apply(): KafkaApiError => 56
   fun string(): String => "Broker(ErrorBrokerAuthorizationFailed/" + apply().string() +
     "): Broker authorization failed."
   fun kafka_official(): Bool => true

--- a/pony-kafka/kafka_handler.pony
+++ b/pony-kafka/kafka_handler.pony
@@ -497,7 +497,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
           c
         end
 
-        ns.data_received(_connection_broker_id, consume copy)
+        ns.data_received(_kafka_client, _connection_broker_id, consume copy)
       end
     end
 
@@ -979,7 +979,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
     ifdef "enable-kafka-network-sniffing" then
       match _conf.network_sniffer
       | let ns: KafkaNetworkSniffer tag =>
-        ns.data_sent(_connection_broker_id, data)
+        ns.data_sent(_kafka_client, _connection_broker_id, data)
       end
     end
 
@@ -1015,7 +1015,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
       for (t, tm) in msgs.pairs() do
         for (p, pm) in tm.pairs() do
           for m in pm.values() do
-            m._send_delivery_report(KafkaProducerDeliveryReport(ErrorNone, t, p,
+            m._send_delivery_report(_kafka_client, KafkaProducerDeliveryReport(ErrorNone, t, p,
                -1, -1, m.get_opaque()))
           end
         end
@@ -1660,7 +1660,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
         match kafka_error
         | ErrorNone =>
           for (i, m) in partition_msgs.pairs() do
-            m._send_delivery_report(KafkaProducerDeliveryReport(kafka_error,
+            m._send_delivery_report(_kafka_client, KafkaProducerDeliveryReport(kafka_error,
               topic, part, part_response.offset + i.i64(),
               part_response.timestamp, m.get_opaque()))
           end
@@ -1693,7 +1693,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
             " and partition: " + part.string() + " error: " +
             kafka_error.string())
           for (i, m) in partition_msgs.pairs() do
-            m._send_delivery_report(KafkaProducerDeliveryReport(kafka_error,
+            m._send_delivery_report(_kafka_client, KafkaProducerDeliveryReport(kafka_error,
               topic, part, part_response.offset + i.i64(),
               part_response.timestamp, m.get_opaque()))
           end
@@ -1829,7 +1829,7 @@ class _KafkaHandler is CustomTCPConnectionNotify
 /* this is related to consumer offset tracking and might get revived when group consumer support is added
                 track_consumer_unacked_message(m)
 */
-                c.receive_kafka_message(consume v, consume key', meta, network_received_timestamp)
+                c.receive_kafka_message(_kafka_client, consume v, consume key', meta, network_received_timestamp)
               else
                 _conf.logger(Fine) and _conf.logger.log(Fine, _name +
                   "Ignoring message because consumer_message_handler returned"

--- a/pony-kafka/kafka_handler.pony
+++ b/pony-kafka/kafka_handler.pony
@@ -1255,26 +1255,27 @@ class _KafkaHandler is CustomTCPConnectionNotify
             part_state.leader_change = true
             part_state.leader_change_receiver = true
           end
-        elseif (part_meta.leader != _connection_broker_id) and
-          (part_state.current_leader == true) then
-          // broker will automagically pause fetch requests for this
-          // partition because leader will be set to -1
-          if not topics_to_throttle.contains(topic) then
-            topics_to_throttle(topic) = recover Set[KafkaPartitionId] end
-          end
-          try
-            topics_to_throttle(topic)?.set(partition_id)
-          else
-            _kafka_client._unrecoverable_error(KafkaErrorReport(ClientErrorShouldNeverHappen(_name +
-              "Unable to set topics_to_throttle for topic: " + topic +
-              " and partition: " + partition_id.string() + "!"),
-            topic, partition_id))
-            return
-          end
-          handle_partition_leader_change(conn,
-            kafka_partition_error, topic, partition_id, Array[ProducerKafkaMessage val], part_state)
         else
-          part_state.current_leader = false
+          if (part_state.current_leader == true) then
+            // broker will automagically pause fetch requests for this
+            // partition because leader will be set to -1
+            if not topics_to_throttle.contains(topic) then
+              topics_to_throttle(topic) = recover Set[KafkaPartitionId] end
+            end
+            try
+              topics_to_throttle(topic)?.set(partition_id)
+            else
+              _kafka_client._unrecoverable_error(KafkaErrorReport(ClientErrorShouldNeverHappen(_name +
+                "Unable to set topics_to_throttle for topic: " + topic +
+                " and partition: " + partition_id.string() + "!"),
+              topic, partition_id))
+              return
+            end
+            handle_partition_leader_change(conn,
+              kafka_partition_error, topic, partition_id, Array[ProducerKafkaMessage val], part_state)
+          else
+            part_state.current_leader = false
+          end
         end
 
         // Due to kafka brokers processing requests sequentially there is no


### PR DESCRIPTION
* remove use of case functions for ponyc master compatibility
* randomize order in which topics/partitions are added to fetch request
  to prevent starvation due to how kafka brokers repond to fetch requests
* replace I32 and other similar types with nicer type aliases
* send list of throttled topic/partitions to producers to simplify interface
* add KafkaClient to all public traits in case a single actor is interacting with multiple client instances
* use KafkaBrokerConnection instead of KafkaNodeId in partition mapping
* Bug fixes related to start offsets and partial messages
* Add space to help message for cli parser
* backport of ponylang/ponyc/#1904 with fix to ponylang/ponyc#2620 for an edge case around the apply_backpressure logic