### PR TITLE
Update hash() functions to return USize

### DIFF
--- a/pony-kafka/kafka_api.pony
+++ b/pony-kafka/kafka_api.pony
@@ -62,7 +62,7 @@ class _KafkaBroker is Equatable[_KafkaBroker box]
   fun ref set_rack(rack': String) =>
     rack = rack'
 
-  fun hash(): U64 =>
+  fun hash(): USize =>
     host.hash() xor port.hash()
 
   fun eq(that: _KafkaBroker box): Bool =>
@@ -167,7 +167,7 @@ class val KafkaTopicPartition is Equatable[KafkaTopicPartition box]
     topic = topic'
     partition_id = partition_id'
 
-  fun hash(): U64 =>
+  fun hash(): USize =>
     topic.hash() xor partition_id.hash()
 
   fun eq(that: KafkaTopicPartition box): Bool =>

--- a/pony-kafka/kafka_config.pony
+++ b/pony-kafka/kafka_config.pony
@@ -512,7 +512,7 @@ class KafkaTopicConfig is Equatable[KafkaTopicConfig box]
         parts'
       end
 
-  fun hash(): U64 =>
+  fun hash(): USize =>
     topic_name.hash()
 
   fun eq(that: KafkaTopicConfig box): Bool =>


### PR DESCRIPTION
This is due to ponylang/ponyc@04f0d04 which changed the return type
of hash() from U64 to USize.